### PR TITLE
Auth shib : conv displayName UTF-8->ISO-8859-1 for filex

### DIFF
--- a/lib/FILEX/System/Auth/AuthShib.pm
+++ b/lib/FILEX/System/Auth/AuthShib.pm
@@ -65,7 +65,7 @@ sub _computeUser {
     return { 
 	id => $headers->{'eppn'},
 	mail => $headers->{$self->{'_config_'}->getMailAttr},
-	real_name => $headers->{$self->{'_config_'}->getUsernameAttr},
+	real_name => Encode::encode("ISO-8859-1", Encode::decode("UTF-8", $headers->{$self->{'_config_'}->getUsernameAttr})),
     };
 }
 


### PR DESCRIPTION
Sur un FileX shibbolethisé, le username dans filex est usuellement le displayName qui est transmis par shibboleth.
Le displayName peut contenir des accents et shibboleth transfère les attributs accentés en UTF-8.
FileX quant à lui travaille en ISO-8859-1.
La modification proposée ici fixe les problèmes d'encodage sur des username contenant des accents et transmis par shibboleth.